### PR TITLE
Add CropRegistration helper and refactor tomato crop

### DIFF
--- a/src/main/java/com/poroteamdev/gtfomodern/ModTabs.java
+++ b/src/main/java/com/poroteamdev/gtfomodern/ModTabs.java
@@ -9,7 +9,7 @@ import net.neoforged.neoforge.registries.DeferredHolder;
 import net.neoforged.neoforge.registries.DeferredRegister;
 
 import com.poroteamdev.gtfomodern.item.Items;
-import com.poroteamdev.gtfomodern.blocks.crops.Seeds;
+import com.poroteamdev.gtfomodern.blocks.crops.CropBlocks;
 
 public class ModTabs {
     public static final DeferredRegister<CreativeModeTab> GTFO_TAB =
@@ -25,10 +25,10 @@ public class ModTabs {
                     .build());
     public static final DeferredHolder<CreativeModeTab, CreativeModeTab> CROP_TAB =
             GTFO_TAB.register("crop_tab", () -> CreativeModeTab.builder()
-                    .icon(() -> new ItemStack(Seeds.TOMATO_SEEDS.get()))
+                    .icon(() -> new ItemStack(CropBlocks.TOMATO.seed().get()))
                     .title(Component.translatable("creativetab.gtfocroptab"))
                     .displayItems(((pParameters, pOutput) -> {
-                        pOutput.accept(Seeds.TOMATO_SEEDS.get());
+                        pOutput.accept(CropBlocks.TOMATO.seed().get());
                     }))
                     .build());
 

--- a/src/main/java/com/poroteamdev/gtfomodern/blocks/crops/CropBlocks.java
+++ b/src/main/java/com/poroteamdev/gtfomodern/blocks/crops/CropBlocks.java
@@ -1,6 +1,7 @@
 package com.poroteamdev.gtfomodern.blocks.crops;
 
 import com.poroteamdev.gtfomodern.blocks.crops.italyupdate.Tomato;
+import com.poroteamdev.gtfomodern.item.Items;
 import net.minecraft.world.item.BlockItem;
 import net.minecraft.world.item.Item;
 import net.minecraft.world.level.block.Block;
@@ -15,8 +16,13 @@ public class CropBlocks {
     public static final DeferredRegister.Blocks BLOCKS = DeferredRegister.createBlocks("gtfomodern");
 
 
-    public static final DeferredBlock<Block> TOMATO_CROP = registerBlock("tomato_crop",
-            () -> new Tomato(BlockBehaviour.Properties.ofFullCopy(Blocks.WHEAT)));
+    public static final CropRegistration<Tomato> TOMATO = CropRegistration.register(
+            "tomato_crop",
+            () -> new Tomato(BlockBehaviour.Properties.ofFullCopy(Blocks.WHEAT)),
+            "tomato_seeds",
+            Items.TOMATO::get,
+            Tomato.AGE
+    );
 
     /*public static final DeferredHolder<Block, Block> MY_BETTER_BLOCK = BLOCKS.register(
             "my_better_block",

--- a/src/main/java/com/poroteamdev/gtfomodern/blocks/crops/CropRegistration.java
+++ b/src/main/java/com/poroteamdev/gtfomodern/blocks/crops/CropRegistration.java
@@ -1,0 +1,41 @@
+package com.poroteamdev.gtfomodern.blocks.crops;
+
+import net.minecraft.world.item.Item;
+import net.minecraft.world.item.ItemNameBlockItem;
+import net.minecraft.world.level.block.CropBlock;
+import net.minecraft.world.level.block.state.properties.IntegerProperty;
+import net.neoforged.neoforge.registries.DeferredBlock;
+import net.neoforged.neoforge.registries.DeferredHolder;
+
+import java.util.function.Supplier;
+
+/**
+ * Helper record storing the crop block and its matching seed item.
+ */
+public record CropRegistration<T extends CropBlock>(
+        DeferredBlock<T> block,
+        DeferredHolder<Item, Item> seed,
+        IntegerProperty ageProperty,
+        Supplier<Item> dropItem) {
+
+    /**
+     * Registers a crop block and its seed item.
+     *
+     * @param cropName        registry name for the crop block
+     * @param blockSupplier   supplier creating the crop block
+     * @param seedName        registry name for the seed item
+     * @param dropItem        supplier of the harvested item
+     * @param ageProperty     property used for the crop age
+     */
+    public static <T extends CropBlock> CropRegistration<T> register(
+            String cropName,
+            Supplier<T> blockSupplier,
+            String seedName,
+            Supplier<Item> dropItem,
+            IntegerProperty ageProperty) {
+        DeferredBlock<T> block = CropBlocks.BLOCKS.register(cropName, blockSupplier);
+        DeferredHolder<Item, Item> seeds = Seeds.ITEMS.register(seedName,
+                () -> new ItemNameBlockItem(block.get(), new Item.Properties()));
+        return new CropRegistration<>(block, seeds, ageProperty, dropItem);
+    }
+}

--- a/src/main/java/com/poroteamdev/gtfomodern/blocks/crops/Seeds.java
+++ b/src/main/java/com/poroteamdev/gtfomodern/blocks/crops/Seeds.java
@@ -1,17 +1,11 @@
 package com.poroteamdev.gtfomodern.blocks.crops;
 
 import net.minecraft.world.item.Item;
-import net.minecraft.world.item.ItemNameBlockItem;
 import net.neoforged.bus.api.IEventBus;
-import net.neoforged.neoforge.registries.DeferredHolder;
 import net.neoforged.neoforge.registries.DeferredRegister;
 
 public class Seeds {
     public static final DeferredRegister<Item> ITEMS = DeferredRegister.createItems("gtfomodern");
-
-    public static final DeferredHolder<Item, Item> TOMATO_SEEDS = ITEMS.register(
-            "tomato_seeds",
-            () -> new ItemNameBlockItem(CropBlocks.TOMATO_CROP.get(), new Item.Properties()));
 
     public static void register(IEventBus modEventBus) {
         ITEMS.register(modEventBus);

--- a/src/main/java/com/poroteamdev/gtfomodern/blocks/crops/italyupdate/Tomato.java
+++ b/src/main/java/com/poroteamdev/gtfomodern/blocks/crops/italyupdate/Tomato.java
@@ -36,7 +36,7 @@ public class Tomato extends CropBlock {
 
     @Override
     protected ItemLike getBaseSeedId() {
-        return Seeds.TOMATO_SEEDS.get();
+        return CropBlocks.TOMATO.seed().get();
     }
 
     @Override

--- a/src/main/java/com/poroteamdev/gtfomodern/datagen/ModBlockLootTableProvider.java
+++ b/src/main/java/com/poroteamdev/gtfomodern/datagen/ModBlockLootTableProvider.java
@@ -1,7 +1,5 @@
 package com.poroteamdev.gtfomodern.datagen;
 import com.poroteamdev.gtfomodern.blocks.crops.CropBlocks;
-import com.poroteamdev.gtfomodern.blocks.crops.Seeds;
-import com.poroteamdev.gtfomodern.blocks.crops.italyupdate.Tomato;
 import com.poroteamdev.gtfomodern.item.Items;
 import net.minecraft.advancements.critereon.StatePropertiesPredicate;
 import net.minecraft.core.Holder;
@@ -22,10 +20,12 @@ public class ModBlockLootTableProvider extends BlockLootSubProvider {
 
     @Override
     protected void generate() {
-        LootItemCondition.Builder lootItemConditionBuilder = LootItemBlockStatePropertyCondition.hasBlockStateProperties(CropBlocks.TOMATO_CROP.get())
-                .setProperties(StatePropertiesPredicate.Builder.properties().hasProperty(Tomato.AGE, 5));
-        this.add(CropBlocks.TOMATO_CROP.get(), this.createCropDrops(CropBlocks.TOMATO_CROP.get(),
-                Items.TOMATO.get(), Seeds.TOMATO_SEEDS.get(), lootItemConditionBuilder));
+        LootItemCondition.Builder lootItemConditionBuilder = LootItemBlockStatePropertyCondition
+                .hasBlockStateProperties(CropBlocks.TOMATO.block().get())
+                .setProperties(StatePropertiesPredicate.Builder.properties().hasProperty(CropBlocks.TOMATO.ageProperty(),
+                        CropBlocks.TOMATO.block().get().getMaxAge()));
+        this.add(CropBlocks.TOMATO.block().get(), this.createCropDrops(CropBlocks.TOMATO.block().get(),
+                Items.TOMATO.get(), CropBlocks.TOMATO.seed().get(), lootItemConditionBuilder));
     }
 
     @Override

--- a/src/main/java/com/poroteamdev/gtfomodern/datagen/ModBlockStateProvider.java
+++ b/src/main/java/com/poroteamdev/gtfomodern/datagen/ModBlockStateProvider.java
@@ -22,7 +22,7 @@ public class ModBlockStateProvider extends BlockStateProvider {
 
     @Override
     protected void registerStatesAndModels() {
-        makeCrop(((CropBlock) CropBlocks.TOMATO_CROP.get()),
+        makeCrop(((CropBlock) CropBlocks.TOMATO.block().get()),
                 "tomato_crop.stage", "tomato_crop.stage");
     }
 

--- a/src/main/java/com/poroteamdev/gtfomodern/datagen/ModItemModelProvider.java
+++ b/src/main/java/com/poroteamdev/gtfomodern/datagen/ModItemModelProvider.java
@@ -1,7 +1,7 @@
 package com.poroteamdev.gtfomodern.datagen;
 
 import com.poroteamdev.gtfomodern.GTFO;
-import com.poroteamdev.gtfomodern.blocks.crops.Seeds;
+import com.poroteamdev.gtfomodern.blocks.crops.CropBlocks;
 import com.poroteamdev.gtfomodern.item.Items;
 import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.data.PackOutput;
@@ -22,7 +22,7 @@ public class ModItemModelProvider extends ItemModelProvider {
     protected void registerModels() {
         flatItem(Items.TOMATO.get(), "components/natural/tomato");
         flatItem(Items.NAQUACHIP.get(),"food/naquachip");
-        flatItem(Seeds.TOMATO_SEEDS.get(),"crops/tomato_seeds");
+        flatItem(CropBlocks.TOMATO.seed().get(),"crops/tomato_seeds");
         flatItem(Items.PEELED_POTATO.get(),"components/potato/peeled_potato");
         flatItem(Items.POTATO_CHIP.get(),"components/potato/potato_chip");
         flatItem(Items.NAQUADAH_CHIP.get(),"components/potato/naquadah_chip");


### PR DESCRIPTION
## Summary
- introduce `CropRegistration` to pair crop blocks with seed items
- register tomato crop/seed using the new helper
- refactor seeds, tabs, item models and datagen to use new helper metadata

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_686d0d5c6e1883319b6d27f407b49e9e